### PR TITLE
Fix Puppeteer issue in the web installer test by disabling sandbox

### DIFF
--- a/screenshot.js
+++ b/screenshot.js
@@ -1,7 +1,9 @@
 const puppeteer = require('puppeteer');
 
 (async () => {
-    const browser = await puppeteer.launch();
+    const browser = await puppeteer.launch({
+        args: ['--no-sandbox'],
+    });
     const page = await browser.newPage();
     const moodleSiteUrl = process.env.MOODLE_SITE_URL || 'http://localhost:8080/moodle';
     const phpVersion = process.argv[2] || 'default';


### PR DESCRIPTION
This resolves the browser launch failure in GitHub Actions by adding --no-sandbox and --disable-setuid-sandbox flags which is necessary for environments without support for Chromium's default sandboxing.