### PR TITLE
Replace outdated PostgreSQL action with Service Container

### DIFF
--- a/.github/workflows/web-installer-test.yml
+++ b/.github/workflows/web-installer-test.yml
@@ -12,11 +12,25 @@ on:
 
 jobs:
   InstallationTest:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: test
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+        ports:
+          - 5432:5432
+        # Health check ensures the DB is ready before steps start
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
         php: [8.3, 8.4]
     steps:
       - name: Checkout repository

--- a/action.yml
+++ b/action.yml
@@ -31,27 +31,6 @@ runs:
         echo "Repository: ${{ inputs.repository }}"
         echo "Branch: ${{ inputs.branch }}"
 
-    - name: Setting up DB PostgreSQL
-      uses: m4nu56/postgresql-action@v1
-      with:
-        postgresql version: 16
-        postgresql db: test
-        postgresql user: test
-        postgresql password: test
-
-    - name: Wait for PostgreSQL to be ready
-      shell: bash
-      run: |
-        for i in {1..30}; do
-        if pg_isready -h localhost -p 5432 -U test; then
-          echo "PostgreSQL is ready"
-          break
-        else
-          echo "Waiting for PostgreSQL to be ready..."
-          sleep 2
-        fi
-        done
-
     - name: Setting up PHP
       uses: shivammathur/setup-php@v2
       with:


### PR DESCRIPTION
The workflow was failing with a Docker API version mismatch (1.40 vs 1.44) because the m4nu56/postgresql-action is outdated and incompatible with current GitHub runners.

The fix replaced the legacy PostgreSQL action with a native GHA Service Container, removed manual "wait for DB" bash scripts (now handled by container health checks).